### PR TITLE
feat!: respect rest convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ You can also directly test the server with cURL:
 
 ```sh
 curl -v -H "Authorization: <apiKey>" http://localhost:9001/cd5331ba/runnables
-curl -v -X POST -H "Authorization: <apiKey>" http://localhost:9001/cd5331ba/runnables/reboot/self
-curl -v -X POST -H "Authorization: <apiKey>" http://localhost:9001/cd5331ba/runnables/stop/self
+curl -v -X POST -H "Authorization: <apiKey>" http://localhost:9001/cd5331ba/runnables/self/reboot
+curl -v -X POST -H "Authorization: <apiKey>" http://localhost:9001/cd5331ba/runnables/self/stop
 ```
 
 ## Creating your own server

--- a/impl/http-server-go/main.go
+++ b/impl/http-server-go/main.go
@@ -37,8 +37,8 @@ func main() {
 	rootPath := fmt.Sprintf("/%s/runnables", config.pathPrefix)
 
 	router.HandleFunc(rootPath, getRunnablesHandler(service)).Methods("GET")
-	router.HandleFunc(fmt.Sprintf("%s/reboot/{id}", rootPath), postRunnableRebootHandler(service)).Methods("POST")
-	router.HandleFunc(fmt.Sprintf("%s/stop/{id}", rootPath), postRunnableStopHandler(service)).Methods("POST")
+	router.HandleFunc(fmt.Sprintf("%s/{id}/reboot", rootPath), postRunnableRebootHandler(service)).Methods("POST")
+	router.HandleFunc(fmt.Sprintf("%s/{id}/stop", rootPath), postRunnableStopHandler(service)).Methods("POST")
 
 	headersCORS := handlers.AllowedHeaders([]string{AUTHORIZATION_HEADER, "Content-Type", "Origin"})
 	methodsCORS := handlers.AllowedMethods([]string{"GET", "HEAD", "OPTIONS", "POST"})

--- a/spec/_generated/swagger.json
+++ b/spec/_generated/swagger.json
@@ -452,7 +452,7 @@
                 ]
             }
         },
-        "/runnables/reboot/{id}": {
+        "/runnables/{id}/reboot": {
             "post": {
                 "operationId": "Reboot",
                 "responses": {
@@ -533,7 +533,7 @@
                 ]
             }
         },
-        "/runnables/stop/{id}": {
+        "/runnables/{id}/stop": {
             "post": {
                 "operationId": "Stop",
                 "responses": {

--- a/spec/controllers/RunnablesController.ts
+++ b/spec/controllers/RunnablesController.ts
@@ -73,7 +73,7 @@ export class RunnablesController extends Controller {
      * @param id
      * @returns
      */
-    @Post('reboot/{id}')
+    @Post('{id}/reboot')
     @SuccessResponse(201)
     @Response<ErrorRes>(401, ERR_401, { message: ERR_401 })
     @Response<ErrorRes>(403, ERR_403, { message: ERR_403 })
@@ -94,7 +94,7 @@ export class RunnablesController extends Controller {
      * @param id
      * @returns
      */
-    @Post('stop/{id}')
+    @Post('{id}/stop')
     @SuccessResponse(201)
     @Response<ErrorRes>(401, ERR_401, { message: ERR_401 })
     @Response<ErrorRes>(403, ERR_403, { message: ERR_403 })


### PR DESCRIPTION
In the convention, a path should be `/resource_name/${id}/operation`.

Therefore, the position of the `${id}` needs to be moved in our current paths for the `reboot` and `stop` endpoints.

This is a breaking change.
